### PR TITLE
adjust dragged item's position

### DIFF
--- a/dist/vue-drag-and-drop-list.js
+++ b/dist/vue-drag-and-drop-list.js
@@ -54,7 +54,7 @@ DragAndDropList.install = function(Vue) {
 
         // Try setting a proper drag image if triggered on a dnd-handle (won't work in IE).
         if (event._dndHandle && event.dataTransfer.setDragImage) {
-          event.dataTransfer.setDragImage(this.el, 0, 0);
+          event.dataTransfer.setDragImage(this.el, event._dndHandleLeft - this.el.getBoundingClientRect().left, event._dndHandleTop - this.el.getBoundingClientRect().top);
         }
 
         // Invoke callback
@@ -430,6 +430,8 @@ DragAndDropList.install = function(Vue) {
       this.handle = function(event){
         event = event.originalEvent || event;
         event._dndHandle = true;
+        event._dndHandleLeft = this.el.getBoundingClientRect().left;
+        event._dndHandleTop = this.el.getBoundingClientRect().top;
       }.bind(this);
 
       this.el.setAttribute('draggable', true);

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ DragAndDropList.install = function(Vue) {
 
         // Try setting a proper drag image if triggered on a dnd-handle (won't work in IE).
         if (event._dndHandle && event.dataTransfer.setDragImage) {
-          event.dataTransfer.setDragImage(this.el, 0, 0);
+          event.dataTransfer.setDragImage(this.el, event._dndHandleLeft - this.el.getBoundingClientRect().left, event._dndHandleTop - this.el.getBoundingClientRect().top);
         }
 
         // Invoke callback
@@ -418,6 +418,8 @@ DragAndDropList.install = function(Vue) {
       this.handle = function(event){
         event = event.originalEvent || event;
         event._dndHandle = true;
+        event._dndHandleLeft = this.el.getBoundingClientRect().left;
+        event._dndHandleTop = this.el.getBoundingClientRect().top;
       }.bind(this);
 
       this.el.setAttribute('draggable', true);


### PR DESCRIPTION
Currently when you drag one item, it flips from its original position to the mouse's.
I changed the code to make it behave as it is.